### PR TITLE
feat: add addon packaging

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,24 @@
+name: Package Addon
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.WOW_PAT }}
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WOW_PAT }}
+
+      - name: Package and Release
+        uses: BigWigsMods/packager@master
+        env:
+          GITHUB_OAUTH_TOKEN: ${{ secrets.WOW_PAT }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}


### PR DESCRIPTION
Hello! I didn't see any notes on the repo about not wanting to publish this. Feel free to ignore if you don't want this feature!

This PR adds a GitHub workflow to the repository for ease of publishing the addon as a GitHub release. I've also included the `WAGO_API_TOKEN` as an example, but can be removed if you don't plan to publish there. Adding just the GH release allows addon managers to be able to pull in new updates as `v.*.*.*` tags are added for new feats/fixes.

This uses [BigWigsMods/packager](https://github.com/BigWigsMods/packager). You will need to create a GH token that has permission to create releases on the repository and add them as a secret to the repo settings (`secrets.WOW_PAT`).

