### PR TITLE
Add Stagger DPS display option for Brewmaster Monks

### DIFF
--- a/Core/Defaults.lua
+++ b/Core/Defaults.lua
@@ -425,7 +425,8 @@ local Defaults = {
                 Enabled = false,
                 FontSize = 12,
                 Colour = {1, 1, 1},
-                Layout = {"CENTER", "CENTER", 0, 0}
+                Layout = {"CENTER", "CENTER", 0, 0},
+                ShowStaggerDPS = false,
             },
         },
         CastBar = {

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -1820,6 +1820,13 @@ local function CreateSecondaryPowerBarSettings(parentContainer)
         colourStaggerByStateCheckbox:SetCallback("OnValueChanged", function(self, _, value) BCDM.db.profile.SecondaryPowerBar.ColourByState = value BCDM:UpdateSecondaryPowerBar() RefreshSecondaryPowerBarGUISettings() end)
         colourStaggerByStateCheckbox:SetRelativeWidth(0.33)
         toggleContainer:AddChild(colourStaggerByStateCheckbox)
+
+        local showStaggerDPSCheckbox = AG:Create("CheckBox")
+        showStaggerDPSCheckbox:SetLabel("Show Stagger DPS")
+        showStaggerDPSCheckbox:SetValue(BCDM.db.profile.SecondaryPowerBar.Text.ShowStaggerDPS)
+        showStaggerDPSCheckbox:SetCallback("OnValueChanged", function(self, _, value) BCDM.db.profile.SecondaryPowerBar.Text.ShowStaggerDPS = value BCDM:UpdateSecondaryPowerBar() end)
+        showStaggerDPSCheckbox:SetRelativeWidth(0.33)
+        toggleContainer:AddChild(showStaggerDPSCheckbox)
     end
 
     local matchAnchorWidthCheckbox = AG:Create("CheckBox")

--- a/Modules/SecondaryPowerBar.lua
+++ b/Modules/SecondaryPowerBar.lua
@@ -454,7 +454,12 @@ local function UpdatePowerValues()
         else
             secondaryPowerBar.Status:SetStatusBarColor(GetPowerBarColor())
         end
-        secondaryPowerBar.Text:SetText(tostring(AbbreviateLargeNumbers(powerCurrent)))
+        local textDisplay = AbbreviateLargeNumbers(powerCurrent)
+        if secondaryPowerBarDB.Text.ShowStaggerDPS and powerCurrent > 0 then
+            local damagePerTick = powerCurrent / 20
+            textDisplay = textDisplay .. " (" .. AbbreviateLargeNumbers(damagePerTick) .. "/0.5s)"
+        end
+        secondaryPowerBar.Text:SetText(textDisplay)
         secondaryPowerBar.Status:Show()
     elseif powerType == Enum.PowerType.Maelstrom then
         powerCurrent = GetAuraStacks(344179)


### PR DESCRIPTION
Shows damage per 0.5s tick alongside total stagger amount. Format: "1.5M (75K/0.5s)"

- Add ShowStaggerDPS config option (default: false)
- Add GUI toggle in SecondaryPowerBar settings for Monks
- Calculate per-tick damage as total stagger / 20 (10s duration / 0.5s ticks)

<img width="1076" height="310" alt="image" src="https://github.com/user-attachments/assets/b082e026-5f3f-472d-acc4-ad4d6e40cce4" />

<img width="541" height="139" alt="image" src="https://github.com/user-attachments/assets/efa3add1-0352-461b-8fcc-27ff406cf7c1" />


