### PR TITLE
Fix Tracked Buffs icon sort order

### DIFF
--- a/Modules/CooldownManager.lua
+++ b/Modules/CooldownManager.lua
@@ -263,6 +263,11 @@ local function CenterBuffs()
             table.insert(visibleBuffIcons, childFrame)
         end
     end
+
+    table.sort(visibleBuffIcons, function(a, b)
+        return (a.layoutIndex or 0) < (b.layoutIndex or 0)
+    end)
+    
     local visibleCount = #visibleBuffIcons
 
     if visibleCount == 0 then return 0 end


### PR DESCRIPTION
When using the "Center Tracked Buffs" functionality buff icon ordering is shuffled (likely due to frame:GetChildren() returning unsorted list of icons.

This is a proposed fix to retain the user defined buff icon order.

Example (AS-IS):
<img width="413" height="122" alt="image" src="https://github.com/user-attachments/assets/3f20dab6-5b74-49d9-928c-306920d90c6d" />

<img width="323" height="86" alt="image" src="https://github.com/user-attachments/assets/6ca9ae71-fde3-47d9-acbe-4603ceeb0e13" />