### PR TITLE
Improve ShouldSkin check for ElvUI

### DIFF
--- a/Modules/CooldownManager.lua
+++ b/Modules/CooldownManager.lua
@@ -3,7 +3,7 @@ local LEMO = LibStub("LibEditModeOverride-1.0")
 
 local function ShouldSkin()
     if not BCDM.db.profile.CooldownManager.Enable then return false end
-    if C_AddOns.IsAddOnLoaded("ElvUI") then return false end
+    if C_AddOns.IsAddOnLoaded("ElvUI") and ElvUI[1].private.skins.blizzard.cooldownManager then return false end
     if C_AddOns.IsAddOnLoaded("MasqueBlizzBars") then return false end
     return true
 end


### PR DESCRIPTION
This will only stop the skinning if the cooldown manager module in ElvUI is enabled