### PR TITLE
[bugfix] fix custom icons falling back to item for any unlearned spells

### DIFF
--- a/Modules/CustomItemSpellViewer.lua
+++ b/Modules/CustomItemSpellViewer.lua
@@ -239,7 +239,12 @@ local function CreateCustomIcons(iconTable)
         table.sort(items, function(a, b) return a.index < b.index end)
 
         for _, item in ipairs(items) do
-            local customItem = item.entryType == "spell" and CreateCustomSpellIcon(item.id) or CreateCustomItemIcon(item.id)
+            local customItem = nil
+            if item.entryType == "spell" then
+                customItem = CreateCustomSpellIcon(item.id)
+            else
+                customItem = CreateCustomItemIcon(item.id)
+            end
             if customItem then
                 table.insert(iconTable, customItem)
             end


### PR DESCRIPTION
Items & Spells would default fallback to creating an Item icon when a spell (with a matching item ID) was unlearned instead of removing it outright

settings:
<img width="348" height="489" alt="image" src="https://github.com/user-attachments/assets/996e1f34-3326-43cf-97a3-5c7a62a8e5ff" />

few examples:
<img width="287" height="72" alt="image" src="https://github.com/user-attachments/assets/6dd53f31-deb5-4884-b7fc-62e802881c64" />
<img width="322" height="144" alt="image" src="https://github.com/user-attachments/assets/1706b5e4-32eb-4291-8112-b3cb59d9e0b3" />

with fix:
<img width="375" height="116" alt="image" src="https://github.com/user-attachments/assets/3b8fef2f-82ae-4354-b80c-3b06750e6d5e" />
<img width="318" height="127" alt="image" src="https://github.com/user-attachments/assets/c761cc6c-8473-4b0d-9922-b87331dd4b8d" />
(think the latter brings out another bug of saturating with differing ranked items in bags, like this alt has r2 pots but no r3 as the list contains, i posted here #42 as to not make a drive-by fix)
