### PR TITLE
Throttle on PLAYER_REGEN_ENABLED

### DIFF
--- a/Core/EventManager.lua
+++ b/Core/EventManager.lua
@@ -31,7 +31,11 @@ function BCDM:SetupEventManager()
     BCDMEventManager:RegisterEvent("TRAIT_CONFIG_UPDATED")
     BCDMEventManager:RegisterEvent("PLAYER_REGEN_ENABLED")
     BCDMEventManager:SetScript("OnEvent", function(_, event, ...)
-        if event == "PLAYER_REGEN_ENABLED" then ApplyPendingChanges() return end
+        if event == "PLAYER_REGEN_ENABLED" then
+            if throttleTimer then throttleTimer:Cancel() end
+            throttleTimer = C_Timer.After(0.2, ApplyPendingChanges)
+            return
+        end
         if event == "PLAYER_SPECIALIZATION_CHANGED" then
             local unit = ...
             if unit ~= "player" then return end


### PR DESCRIPTION
Got an error that I believe is due to not having throttle on PLAYER_REGEN_ENABLED

1x ...ibraries/LibEditModeOverride/LibEditModeOverride.lua:201: Cannot move frames in combat
[BetterCooldownManager/Libraries/LibEditModeOverride/LibEditModeOverride.lua]:201: in function 'ApplyChanges'
[BetterCooldownManager/Core/EventManager.lua]:14: in function <...eBetterCooldownManager/Core/EventManager.lua:9>