### PR TITLE
Fix Maelstrom Weapon stacks not updating from auto-attacks on Enhancement Shaman

### DIFF
--- a/Modules/SecondaryPowerBar.lua
+++ b/Modules/SecondaryPowerBar.lua
@@ -738,6 +738,7 @@ function BCDM:CreateSecondaryPowerBar()
         secondaryPowerBar:RegisterEvent("UPDATE_SHAPESHIFT_COOLDOWN")
         secondaryPowerBar:RegisterEvent("RUNE_POWER_UPDATE")
         secondaryPowerBar:RegisterEvent("RUNE_TYPE_UPDATE")
+        secondaryPowerBar:RegisterEvent("UNIT_AURA")
 
         secondaryPowerBar:SetScript("OnEvent", function(self, event, ...)
             if event == "RUNE_POWER_UPDATE" or event == "RUNE_TYPE_UPDATE" then
@@ -747,7 +748,8 @@ function BCDM:CreateSecondaryPowerBar()
                 return
             end
             if event == "UNIT_POWER_UPDATE" or event == "UNIT_MAXPOWER" or event == "UNIT_HEALTH"
-                or event == "UNIT_MAXHEALTH" or event == "UNIT_ABSORB_AMOUNT_CHANGED" then
+                or event == "UNIT_MAXHEALTH" or event == "UNIT_ABSORB_AMOUNT_CHANGED"
+                or event == "UNIT_AURA" then                
                 local unit = ...
                 if unit and unit ~= "player" then return end
             end


### PR DESCRIPTION
Fix Maelstrom Weapon stack updates on auto-attacks

- Register `UNIT_AURA` event on the SecondaryPowerBar frame  
- Add `UNIT_AURA` to the event handler filter  

This ensures the bar updates correctly when Maelstrom Weapon stacks change due to auto-attacks (white hits), which only trigger `UNIT_AURA` and not `UNIT_POWER_UPDATE`. Previously, stacks only updated when casting spells.

Resolves issue where Enhancement Shaman secondary power bar was not updating in real-time during auto-attack phases.