### PR TITLE
Fix: Spellbook race condition breaking cooldown bars on spec/talent changes

### DIFF
--- a/Core/EventManager.lua
+++ b/Core/EventManager.lua
@@ -6,14 +6,22 @@ function BCDM:SetupEventManager()
     BCDMEventManager:RegisterEvent("PLAYER_ENTERING_WORLD")
     BCDMEventManager:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
     BCDMEventManager:RegisterEvent("TRAIT_CONFIG_UPDATED")
+    BCDMEventManager:RegisterEvent("SPELLS_CHANGED")
     BCDMEventManager:SetScript("OnEvent", function(_, event, ...)
         if InCombatLockdown() then return end
         if event == "PLAYER_SPECIALIZATION_CHANGED" then
             local unit = ...
             if unit ~= "player" then return end
+            -- Only apply LEMO changes here; wait for SPELLS_CHANGED to update cooldown viewers
             LEMO:ApplyChanges()
+        elseif event == "SPELLS_CHANGED" then
+            -- Spellbook is now ready - safe to call UpdateBCDM
             BCDM:UpdateBCDM()
+        elseif event == "TRAIT_CONFIG_UPDATED" then
+            -- Talents changed - wait for SPELLS_CHANGED to fire
+            -- (no action needed here, SPELLS_CHANGED will follow)
         else
+            -- PLAYER_ENTERING_WORLD
             BCDM:UpdateBCDM()
         end
     end)

--- a/Core/Globals.lua
+++ b/Core/Globals.lua
@@ -450,6 +450,7 @@ function BCDM:RepositionSecondaryBar()
     local specIndex = GetSpecialization()
     if not specIndex then return false end
     local specID = GetSpecializationInfo(specIndex)
+    if not specID then return false end
     local classSpecs = SpecsNeedingAltPower[class]
     if not classSpecs then return false end
     for _, requiredSpec in ipairs(classSpecs) do if specID == requiredSpec then return true end end

--- a/Modules/AdditionalCustomCooldownViewer.lua
+++ b/Modules/AdditionalCustomCooldownViewer.lua
@@ -128,7 +128,11 @@ end
 
 local function CreateCustomIcons(iconTable)
     local playerClass = select(2, UnitClass("player"))
-    local playerSpecialization = select(2, GetSpecializationInfo(GetSpecialization())):gsub(" ", ""):upper()
+    local specIndex = GetSpecialization()
+    if not specIndex then return end
+    local specInfo = GetSpecializationInfo(specIndex)
+    if not specInfo then return end
+    local playerSpecialization = select(2, GetSpecializationInfo(specIndex)):gsub(" ", ""):upper()
     local DefensiveSpells = BCDM.db.profile.CooldownManager.AdditionalCustom.Spells
 
     wipe(iconTable)

--- a/Modules/CustomCooldownViewer.lua
+++ b/Modules/CustomCooldownViewer.lua
@@ -125,7 +125,11 @@ end
 
 local function CreateCustomIcons(iconTable)
     local playerClass = select(2, UnitClass("player"))
-    local playerSpecialization = select(2, GetSpecializationInfo(GetSpecialization())):gsub(" ", ""):upper()
+    local specIndex = GetSpecialization()
+    if not specIndex then return end
+    local specInfo = GetSpecializationInfo(specIndex)
+    if not specInfo then return end
+    local playerSpecialization = select(2, GetSpecializationInfo(specIndex)):gsub(" ", ""):upper()
     local DefensiveSpells = BCDM.db.profile.CooldownManager.Custom.Spells
 
     wipe(iconTable)

--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -336,7 +336,11 @@ function BCDM:AddRecommendedSpells(customDB)
     local CooldownManagerDB = BCDM.db.profile
     local CustomDB = CooldownManagerDB.CooldownManager[customDB]
     local _, playerClass = UnitClass("player")
-    local playerSpecialization = select(2, GetSpecializationInfo(GetSpecialization())):gsub(" ", ""):upper()
+    local specIndex = GetSpecialization()
+    if not specIndex then return end
+    local specInfo = GetSpecializationInfo(specIndex)
+    if not specInfo then return end
+    local playerSpecialization = select(2, GetSpecializationInfo(specIndex)):gsub(" ", ""):upper()
     if DEFENSIVE_SPELLS[playerClass] and DEFENSIVE_SPELLS[playerClass][playerSpecialization] then
         for spellId, data in pairs(DEFENSIVE_SPELLS[playerClass][playerSpecialization]) do
             if not CustomDB.Spells[playerClass] then CustomDB.Spells[playerClass] = {} end


### PR DESCRIPTION
## The Problem

Been loving BCDM but hit a frustrating issue - every time I swap specs (or even just change a talent), my custom cooldown bars completely break. Had to `/reload` every single time just to get them working again. Pretty annoying when you're trying to quickly swap from Holy to Ret between pulls!

After some digging, found the root cause: the addon listens for `PLAYER_SPECIALIZATION_CHANGED` and `TRAIT_CONFIG_UPDATED`, but these events fire **before** the spellbook actually updates. So when the addon calls `C_SpellBook.IsSpellInSpellBook()`, it's checking against stale data and everything falls apart.

## The Fix

- Added `SPELLS_CHANGED` event listener - this fires when the spellbook is actually ready with the new spells
- Moved the `UpdateBCDM()` call from spec/talent events to `SPELLS_CHANGED`
- Added nil safety checks for `GetSpecialization()` which can return nil during the transition window (was causing Lua errors)

## Changes

| File | Change |
|------|--------|
| `Core/EventManager.lua` | Main fix - register SPELLS_CHANGED, reorganize event handling |
| `Modules/CustomCooldownViewer.lua` | Nil safety for GetSpecialization() |
| `Modules/AdditionalCustomCooldownViewer.lua` | Nil safety for GetSpecialization() |
| `Modules/Data.lua` | Nil safety in AddRecommendedSpells() |
| `Core/Globals.lua` | Nil safety in RepositionSecondaryBar() |

## Testing

Tested extensively:
- ✅ Swapping between all specs on my Paladin
- ✅ Changing talents mid-dungeon
- ✅ Leveling up and gaining new talents
- ✅ No more Lua errors with `/console scriptErrors 1`
- ✅ Cooldown bars update correctly without needing /reload

## Before & After

**Before:** Swap spec → cooldown bars break → have to /reload  
**After:** Swap spec → bars update automatically → keep playing 🎉

Cheers Dale, love the addon!