### PR TITLE
Added Opacity Slider for Item, Custom and Aditional Custom Viewers

### DIFF
--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -1878,7 +1878,20 @@ local function CreateCooldownViewerItemSpellSettings(parentContainer, containerT
                 RefreshItemSpellSettings()
             end)
             parentContainer:AddChild(removeItemButton)
-
+            
+            if viewerType == "Item" or viewerType == "Custom" or viewerType == "AdditionalCustom" then
+                local barAlphaSlider = AG:Create("Slider")
+                barAlphaSlider:SetLabel(LL("Bar Opacity"))
+                barAlphaSlider:SetValue(BCDM.db.profile.CooldownManager[viewerType].BarAlpha or 1)
+                barAlphaSlider:SetSliderValues(0, 1, 0.01)
+                barAlphaSlider:SetIsPercent(true)
+                barAlphaSlider:SetCallback("OnValueChanged", function(self, _, value)
+                    BCDM.db.profile.CooldownManager[viewerType].BarAlpha = value
+                    BCDM:UpdateCooldownViewer(viewerType)
+                end)
+                barAlphaSlider:SetRelativeWidth(0.33)
+                layoutContainer:AddChild(barAlphaSlider)
+            end
             AddItemSpellClassSpecFilterEditor(parentContainer, "ItemSpell", "ItemSpell", itemId, data, RefreshItemSpellSettings)
         end
     end

--- a/CustomViewers/AdditionalCustomCooldownViewer.lua
+++ b/CustomViewers/AdditionalCustomCooldownViewer.lua
@@ -368,7 +368,7 @@ local function LayoutAdditionalCustomCooldownViewer()
             spellIcon:Show()
         end
     end
-
+    BCDM.AdditionalCustomCooldownViewerContainer:SetAlpha(CustomDB.BarAlpha or 1)
     BCDM.AdditionalCustomCooldownViewerContainer:Show()
 end
 

--- a/CustomViewers/CustomCooldownViewer.lua
+++ b/CustomViewers/CustomCooldownViewer.lua
@@ -368,7 +368,7 @@ local function LayoutCustomCooldownViewer()
             spellIcon:Show()
         end
     end
-
+    BCDM.CustomCooldownViewerContainer:SetAlpha(CustomDB.BarAlpha or 1)
     BCDM.CustomCooldownViewerContainer:Show()
 end
 

--- a/CustomViewers/CustomItemViewer.lua
+++ b/CustomViewers/CustomItemViewer.lua
@@ -702,7 +702,7 @@ local function LayoutCustomItemBar()
             spellIcon:Show()
         end
     end
-
+    BCDM.CustomItemBarContainer:SetAlpha(CustomDB.BarAlpha or 1)
     BCDM.CustomItemBarContainer:Show()
 end
 


### PR DESCRIPTION
Slider bar for each one. Custom, Aditional Custom and Item Viewers.
Slider applies alpha 0-100 % to the entire viewer.

Tested in game and working

<img width="336" height="138" alt="image" src="https://github.com/user-attachments/assets/7044edcb-ed08-4ce3-baa0-91b76c946c82" />
<img width="927" height="326" alt="image" src="https://github.com/user-attachments/assets/eca64e96-d068-4a97-8826-89457f6d296a" />
