### PR TITLE
Add DandersFrames as an anchor parent; inherit anchor visibility

### DIFF
--- a/Core/Globals.lua
+++ b/Core/Globals.lua
@@ -503,20 +503,24 @@ BCDM.AnchorParents = {
             ["EssentialCooldownViewer"] = "|cFF00AEF7Blizzard|r: Essential Cooldown Viewer",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
         },
-        { "EssentialCooldownViewer", "NONE", "BCDM_PowerBar", "BCDM_SecondaryPowerBar"},
+        { "EssentialCooldownViewer", "NONE", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar"},
     },
     ["Buffs"] = {
         {
             ["EssentialCooldownViewer"] = "|cFF00AEF7Blizzard|r: Essential Cooldown Viewer",
             ["UtilityCooldownViewer"] = "|cFF00AEF7Blizzard|r: Utility Cooldown Viewer",
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
             ["BCDM_CastBar"] = "|cFF8080FFBCDM|r: Cast Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CastBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CastBar" },
     },
     ["Custom"] = {
         {
@@ -612,26 +616,32 @@ BCDM.AnchorParents = {
         {
             ["EssentialCooldownViewer"] = "|cFF00AEF7Blizzard|r: Essential Cooldown Viewer",
             ["UtilityCooldownViewer"] = "|cFF00AEF7Blizzard|r: Utility Cooldown Viewer",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "BCDM_SecondaryPowerBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_SecondaryPowerBar" },
     },
     ["SecondaryPower"] = {
         {
             ["EssentialCooldownViewer"] = "|cFF00AEF7Blizzard|r: Essential Cooldown Viewer",
             ["UtilityCooldownViewer"] = "|cFF00AEF7Blizzard|r: Utility Cooldown Viewer",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "BCDM_PowerBar"},
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar"},
     },
     ["CastBar"] = {
         {
             ["EssentialCooldownViewer"] = "|cFF00AEF7Blizzard|r: Essential Cooldown Viewer",
             ["UtilityCooldownViewer"] = "|cFF00AEF7Blizzard|r: Utility Cooldown Viewer",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar" },
     }
 }
 

--- a/Core/Globals.lua
+++ b/Core/Globals.lua
@@ -525,6 +525,8 @@ BCDM.AnchorParents = {
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
             ["PlayerFrame"] = "|cFF00AEF7Blizzard|r: Player Frame",
             ["TargetFrame"] = "|cFF00AEF7Blizzard|r: Target Frame",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
             ["BCDM_AdditionalCustomCooldownViewer"] = "|cFF8080FFBCDM|r: Additional Custom Bar",
@@ -532,7 +534,7 @@ BCDM.AnchorParents = {
             ["BCDM_CustomItemBar"] = "|cFF8080FFBCDM|r: Item Bar",
             ["BCDM_TrinketBar"] = "|cFF8080FFBCDM|r: Trinket Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_CustomItemSpellBar", "BCDM_TrinketBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_CustomItemSpellBar", "BCDM_TrinketBar" },
     },
     ["AdditionalCustom"] = {
         {
@@ -541,6 +543,8 @@ BCDM.AnchorParents = {
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
             ["PlayerFrame"] = "|cFF00AEF7Blizzard|r: Player Frame",
             ["TargetFrame"] = "|cFF00AEF7Blizzard|r: Target Frame",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
             ["BCDM_CustomCooldownViewer"] = "|cFF8080FFBCDM|r: Custom Bar",
@@ -548,7 +552,7 @@ BCDM.AnchorParents = {
             ["BCDM_CustomItemSpellBar"] = "|cFF8080FFBCDM|r: Items/Spells Bar",
             ["BCDM_TrinketBar"] = "|cFF8080FFBCDM|r: Trinket Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_CustomItemSpellBar", "BCDM_TrinketBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_CustomItemSpellBar", "BCDM_TrinketBar" },
     },
     ["Item"] = {
         {
@@ -557,6 +561,8 @@ BCDM.AnchorParents = {
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
             ["PlayerFrame"] = "|cFF00AEF7Blizzard|r: Player Frame",
             ["TargetFrame"] = "|cFF00AEF7Blizzard|r: Target Frame",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
             ["BCDM_CustomCooldownViewer"] = "|cFF8080FFBCDM|r: Custom Bar",
@@ -564,7 +570,7 @@ BCDM.AnchorParents = {
             ["BCDM_CustomItemSpellBar"] = "|cFF8080FFBCDM|r: Items/Spells Bar",
             ["BCDM_TrinketBar"] = "|cFF8080FFBCDM|r: Trinket Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemSpellBar", "BCDM_TrinketBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemSpellBar", "BCDM_TrinketBar" },
     },
     ["Trinket"] = {
         {
@@ -573,6 +579,8 @@ BCDM.AnchorParents = {
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
             ["PlayerFrame"] = "|cFF00AEF7Blizzard|r: Player Frame",
             ["TargetFrame"] = "|cFF00AEF7Blizzard|r: Target Frame",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
             ["BCDM_CustomCooldownViewer"] = "|cFF8080FFBCDM|r: Custom Bar",
@@ -580,7 +588,7 @@ BCDM.AnchorParents = {
             ["BCDM_CustomItemBar"] = "|cFF8080FFBCDM|r: Item Bar",
             ["BCDM_CustomItemSpellBar"] = "|cFF8080FFBCDM|r: Items/Spells Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_CustomItemSpellBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_CustomItemSpellBar" },
     },
     ["ItemSpell"] = {
         {
@@ -589,6 +597,8 @@ BCDM.AnchorParents = {
             ["NONE"] = "|cFF00AEF7Blizzard|r: UIParent",
             ["PlayerFrame"] = "|cFF00AEF7Blizzard|r: Player Frame",
             ["TargetFrame"] = "|cFF00AEF7Blizzard|r: Target Frame",
+            ["DandersPartyHeader"] = "|cFFFFA500DandersFrames|r: Party Header",
+            ["DandersRaidFramesContainer"] = "|cFFFFA500DandersFrames|r: Raid Container",
             ["BCDM_PowerBar"] = "|cFF8080FFBCDM|r: Power Bar",
             ["BCDM_SecondaryPowerBar"] = "|cFF8080FFBCDM|r: Secondary Power Bar",
             ["BCDM_CustomCooldownViewer"] = "|cFF8080FFBCDM|r: Custom Bar",
@@ -596,7 +606,7 @@ BCDM.AnchorParents = {
             ["BCDM_CustomItemBar"] = "|cFF8080FFBCDM|r: Item Bar",
             ["BCDM_TrinketBar"] = "|cFF8080FFBCDM|r: Trinket Bar",
         },
-        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_TrinketBar" },
+        { "EssentialCooldownViewer", "UtilityCooldownViewer", "NONE", "PlayerFrame", "TargetFrame", "DandersPartyHeader", "DandersRaidFramesContainer", "BCDM_PowerBar", "BCDM_SecondaryPowerBar", "BCDM_CustomCooldownViewer", "BCDM_AdditionalCustomCooldownViewer", "BCDM_CustomItemBar", "BCDM_TrinketBar" },
     },
     ["Power"] = {
         {

--- a/CustomViewers/AdditionalCustomCooldownViewer.lua
+++ b/CustomViewers/AdditionalCustomCooldownViewer.lua
@@ -121,7 +121,7 @@ local function CreateCustomIcon(spellId)
     end
     local iconWidth, iconHeight = BCDM:GetIconDimensions(CustomDB)
     customIcon:SetSize(iconWidth, iconHeight)
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
     customIcon:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     customIcon:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     customIcon:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -258,7 +258,8 @@ local function LayoutAdditionalCustomCooldownViewer()
 
     BCDM.AdditionalCustomCooldownViewerContainer:ClearAllPoints()
     BCDM.AdditionalCustomCooldownViewerContainer:SetFrameStrata(CustomDB.FrameStrata or "LOW")
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+    BCDM.AdditionalCustomCooldownViewerContainer:SetParent(anchorParent)
     BCDM.AdditionalCustomCooldownViewerContainer:SetPoint(containerAnchorFrom, anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
 
     for _, child in ipairs({BCDM.AdditionalCustomCooldownViewerContainer:GetChildren()}) do child:UnregisterAllEvents() child:Hide() child:SetParent(nil) end
@@ -383,7 +384,8 @@ function BCDM:UpdateAdditionalCustomCooldownViewer()
     local CustomDB = CooldownManagerDB.CooldownManager.AdditionalCustom
     if BCDM.AdditionalCustomCooldownViewerContainer then
         BCDM.AdditionalCustomCooldownViewerContainer:ClearAllPoints()
-        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+        BCDM.AdditionalCustomCooldownViewerContainer:SetParent(anchorParent)
         BCDM.AdditionalCustomCooldownViewerContainer:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     end
     LayoutAdditionalCustomCooldownViewer()

--- a/CustomViewers/CustomCooldownViewer.lua
+++ b/CustomViewers/CustomCooldownViewer.lua
@@ -121,7 +121,7 @@ local function CreateCustomIcon(spellId)
     end
     local iconWidth, iconHeight = BCDM:GetIconDimensions(CustomDB)
     customIcon:SetSize(iconWidth, iconHeight)
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
     customIcon:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     customIcon:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     customIcon:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -257,7 +257,8 @@ local function LayoutCustomCooldownViewer()
 
     BCDM.CustomCooldownViewerContainer:ClearAllPoints()
     BCDM.CustomCooldownViewerContainer:SetFrameStrata(CustomDB.FrameStrata or "LOW")
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+    BCDM.CustomCooldownViewerContainer:SetParent(anchorParent)
     BCDM.CustomCooldownViewerContainer:SetPoint(containerAnchorFrom, anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
 
     for _, child in ipairs({BCDM.CustomCooldownViewerContainer:GetChildren()}) do child:UnregisterAllEvents() child:Hide() child:SetParent(nil) end
@@ -383,7 +384,8 @@ function BCDM:UpdateCustomCooldownViewer()
     local CustomDB = CooldownManagerDB.CooldownManager.Custom
     if BCDM.CustomCooldownViewerContainer then
         BCDM.CustomCooldownViewerContainer:ClearAllPoints()
-        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+        BCDM.CustomCooldownViewerContainer:SetParent(anchorParent)
         BCDM.CustomCooldownViewerContainer:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     end
     LayoutCustomCooldownViewer()

--- a/CustomViewers/CustomItemSpellViewer.lua
+++ b/CustomViewers/CustomItemSpellViewer.lua
@@ -347,7 +347,7 @@ local function CreateCustomItemIcon(itemId)
     end
     local iconWidth, iconHeight = BCDM:GetIconDimensions(CustomDB)
     customIcon:SetSize(iconWidth, iconHeight)
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
     customIcon:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     customIcon:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     customIcon:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -452,7 +452,7 @@ local function CreateCustomSpellIcon(spellId)
     end
     local iconWidth, iconHeight = BCDM:GetIconDimensions(CustomDB)
     customIcon:SetSize(iconWidth, iconHeight)
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
     customIcon:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     customIcon:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     customIcon:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -653,7 +653,8 @@ local function LayoutCustomItemsSpellsBar()
 
     BCDM.CustomItemSpellBarContainer:ClearAllPoints()
     BCDM.CustomItemSpellBarContainer:SetFrameStrata(CustomDB.FrameStrata or "LOW")
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+    BCDM.CustomItemSpellBarContainer:SetParent(anchorParent)
     BCDM.CustomItemSpellBarContainer:SetPoint(containerAnchorFrom, anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     if not BCDM.CustomItemSpellBarContainer.HideZeroEventHooked then
         BCDM.CustomItemSpellBarContainer.HideZeroEventHooked = true
@@ -824,7 +825,8 @@ function BCDM:UpdateCustomItemsSpellsBar()
     local CustomDB = CooldownManagerDB.CooldownManager.ItemSpell
     if BCDM.CustomItemSpellBarContainer then
         BCDM.CustomItemSpellBarContainer:ClearAllPoints()
-        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+        BCDM.CustomItemSpellBarContainer:SetParent(anchorParent)
         BCDM.CustomItemSpellBarContainer:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     end
     LayoutCustomItemsSpellsBar()

--- a/CustomViewers/CustomItemViewer.lua
+++ b/CustomViewers/CustomItemViewer.lua
@@ -312,7 +312,7 @@ local function CreateCustomIcon(itemId)
     end
     local iconWidth, iconHeight = BCDM:GetIconDimensions(CustomDB)
     customIcon:SetSize(iconWidth, iconHeight)
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
     customIcon:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     customIcon:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     customIcon:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -525,7 +525,8 @@ local function LayoutCustomItemBar()
 
     BCDM.CustomItemBarContainer:ClearAllPoints()
     BCDM.CustomItemBarContainer:SetFrameStrata(CustomDB.FrameStrata or "LOW")
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+    BCDM.CustomItemBarContainer:SetParent(anchorParent)
     BCDM.CustomItemBarContainer:SetPoint(containerAnchorFrom, anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
 
     if not BCDM.CustomItemBarContainer.HideZeroEventHooked then
@@ -717,7 +718,8 @@ function BCDM:UpdateCustomItemBar()
     local CustomDB = CooldownManagerDB.CooldownManager.Item
     if BCDM.CustomItemBarContainer then
         BCDM.CustomItemBarContainer:ClearAllPoints()
-        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+        BCDM.CustomItemBarContainer:SetParent(anchorParent)
         BCDM.CustomItemBarContainer:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     end
     LayoutCustomItemBar()

--- a/CustomViewers/TrinketBar.lua
+++ b/CustomViewers/TrinketBar.lua
@@ -102,7 +102,7 @@ local function CreateCustomIcon(itemId, slotID)
     end
     local iconWidth, iconHeight = BCDM:GetIconDimensions(CustomDB)
     customIcon:SetSize(iconWidth, iconHeight)
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
     customIcon:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
     customIcon:RegisterEvent("SPELL_UPDATE_COOLDOWN")
     customIcon:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -191,7 +191,8 @@ local function LayoutTrinketBar()
 
     BCDM.TrinketBarContainer:ClearAllPoints()
     BCDM.TrinketBarContainer:SetFrameStrata(CustomDB.FrameStrata or "LOW")
-    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+    local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+    BCDM.TrinketBarContainer:SetParent(anchorParent)
     BCDM.TrinketBarContainer:SetPoint(containerAnchorFrom, anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
 
     for _, child in ipairs({BCDM.TrinketBarContainer:GetChildren()}) do child:UnregisterAllEvents() child:Hide() child:SetParent(nil) end
@@ -290,7 +291,8 @@ function BCDM:UpdateTrinketBar()
     local isEnabled = CustomDB.Enabled
     if BCDM.TrinketBarContainer and isEnabled then
         BCDM.TrinketBarContainer:ClearAllPoints()
-        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]]
+        local anchorParent = CustomDB.Layout[2] == "NONE" and UIParent or _G[CustomDB.Layout[2]] or UIParent
+        BCDM.TrinketBarContainer:SetParent(anchorParent)
         BCDM.TrinketBarContainer:SetPoint(CustomDB.Layout[1], anchorParent, CustomDB.Layout[3], CustomDB.Layout[4], CustomDB.Layout[5])
         LayoutTrinketBar()
     else


### PR DESCRIPTION
## Summary

Adds **DandersFrames** ([CurseForge](https://www.curseforge.com/wow/addons/dandersframes)) as a selectable anchor parent in the custom viewer categories, so users can anchor BCDM bars (Custom / Additional Custom / Item / Items-Spells / Trinket) to their party/raid unit frames.

## Changes

### `Core/Globals.lua`
Added two anchor keys to the `BCDM.AnchorParents` table for the 5 custom viewer categories (`Custom`, `AdditionalCustom`, `Item`, `Trinket`, `ItemSpell`):

- `DandersPartyHeader` — the party `SecureGroupHeaderTemplate` frame (auto-sized to the visible party frames).
- `DandersRaidFramesContainer` — the raid container frame.

Both frames are top-level globals created by DandersFrames, so they resolve through the existing `_G[Layout[2]]` lookup with no additional load-order requirements. If DandersFrames isn't installed, the option is still shown but falls back to `UIParent` (see below).

### `CustomViewers/*.lua` (5 files)
Two small robustness fixes applied uniformly to every `anchorParent` resolution site:

1. **`or UIParent` fallback** — if the saved anchor key refers to a frame that no longer exists (e.g. user disabled the anchor addon), `_G[key]` returns `nil`; falling back to `UIParent` avoids `SetParent(nil)` / `SetPoint(..., nil, ...)` errors.

2. **`container:SetParent(anchorParent)`** added next to each `container:SetPoint(..., anchorParent, ...)` call for the 5 viewer containers (`CustomCooldownViewer`, `AdditionalCustomCooldownViewer`, `CustomItemBar`, `CustomItemSpellBar`, `TrinketBar`).

   Re-parenting makes the BCDM container inherit visibility from the anchor. This is necessary for DandersFrames (the raid container is hidden in party mode and vice-versa), and it also aligns behavior with other addons that hide their frames conditionally. Icons previously remained visible in their old position even when the anchor frame was hidden.

## Testing

- Anchored the Custom bar to `DandersFrames: Party Header` / `DandersFrames: Raid Container` and verified it tracks the frames and hides together with them when switching DandersFrames profiles between party and raid modes.
- Verified existing anchors (`UIParent`, `PlayerFrame`, `TargetFrame`, other BCDM bars, ElvUI frames) still work unchanged.
- Verified no errors when switching profiles to one that references a missing anchor.

## Notes

- No new dependencies. DandersFrames is optional — if it's not installed, the options simply fall back to `UIParent`.
- No saved-variable migration needed; this only adds new entries to the dropdown list.